### PR TITLE
Disable buggy strict path validation

### DIFF
--- a/init.cfg.tftpl
+++ b/init.cfg.tftpl
@@ -34,7 +34,8 @@ runcmd:
     microk8s helm3 install ingress-nginx ingress-nginx/ingress-nginx --namespace ingress-nginx --create-namespace \
       --set "controller.service.type=NodePort" \
       --set "controller.service.nodePorts.http=${http_port}" \
-      --set "controller.service.nodePorts.https=${https_port}"
+      --set "controller.service.nodePorts.https=${https_port}" \
+      --set "controller.config.strict-validate-path-type=false"
   - |
     if [ "${enable_cert_manager}" = "true" ]; then
       echo "Installing cert-manager ..."


### PR DESCRIPTION
Per [Release 1.18 - cert-manager Documentation](https://cert-manager.io/docs/releases/release-notes/release-notes-1.18/), disable strict path validation, to work around [a bug in ingress-nginx](https://github.com/kubernetes/ingress-nginx/issues/11176)