### PR TITLE
Turn off feature gate ACMEHTTP01IngressPathTypeExact

### DIFF
--- a/init.cfg.tftpl
+++ b/init.cfg.tftpl
@@ -38,7 +38,9 @@ runcmd:
   - |
     if [ "${enable_cert_manager}" = "true" ]; then
       echo "Installing cert-manager ..."
-      microk8s helm3 install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set "crds.enabled=true"
+      microk8s helm3 install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace \
+        --set "crds.enabled=true" \
+        --set "config.featureGates.ACMEHTTP01IngressPathTypeExact=false"
       echo "Installing Let's Encrypt cluster-issuer with email ${email} ..."
       microk8s helm3 install cluster-issuer pacroy/cluster-issuer --namespace cert-manager --set "email=${email}"
     fi


### PR DESCRIPTION
This pull request makes a small update to the cert-manager installation process in the `init.cfg.tftpl` file. The change adds a new Helm value to the installation command to explicitly set the `ACMEHTTP01IngressPathTypeExact` feature gate to `false`. This ensures consistent behavior for ACME HTTP-01 challenges during certificate management.

* Added `--set "config.featureGates.ACMEHTTP01IngressPathTypeExact=false"` to the `cert-manager` Helm install command in `init.cfg.tftpl` to control the ACME HTTP-01 ingress path type feature.