### PR TITLE
Revert recent changes

### DIFF
--- a/init.cfg.tftpl
+++ b/init.cfg.tftpl
@@ -25,16 +25,17 @@ runcmd:
     chmod 600 /home/${admin_username}/admin.config
   - |
     echo "Configuring helm3 ..."
-    microk8s helm3 repo add nginx-stable https://helm.nginx.com/stable
+    microk8s helm3 repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
     microk8s helm3 repo add jetstack https://charts.jetstack.io
     microk8s helm3 repo add pacroy https://pacroy.github.io/helm-repo
     microk8s helm3 repo update
     sleep 10
-    echo "Install nginx-ingress at port ${http_port}/${https_port} ..."
-    microk8s helm3 install nginx-ingress nginx-stable/nginx-ingress --namespace nginx-ingress --create-namespace \
+    echo "Install ingress-nginx at port ${http_port}/${https_port} ..."
+    microk8s helm3 install ingress-nginx ingress-nginx/ingress-nginx --namespace ingress-nginx --create-namespace \
       --set "controller.service.type=NodePort" \
       --set "controller.service.nodePorts.http=${http_port}" \
-      --set "controller.service.nodePorts.https=${https_port}"
+      --set "controller.service.nodePorts.https=${https_port}" \
+      --set "controller.config.strict-validate-path-type=false"
   - |
     if [ "${enable_cert_manager}" = "true" ]; then
       echo "Installing cert-manager ..."


### PR DESCRIPTION
This pull request reverts the project from using the F5 NGINX Ingress Controller back to the community-maintained `ingress-nginx` controller. The documentation and initialization scripts are updated to reflect this change, and the previous migration guide for F5 NGINX is removed.

**Ingress Controller Changes:**

* Switched the Helm repository and installation commands in `init.cfg.tftpl` from `nginx-stable/nginx-ingress` (F5 NGINX) to `ingress-nginx/ingress-nginx` (community ingress-nginx).
* Updated references in `README.md` to use `ingress-nginx` instead of F5 NGINX Ingress Controller, including links and descriptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31)

**Documentation Updates:**

* Removed the migration guide section in `README.md` related to moving from `ingress-nginx` to F5 NGINX Ingress Controller, as this is no longer relevant.
* Adjusted the installation instructions and resource descriptions to match the use of `ingress-nginx`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31)

**Cert-Manager Installation:**

* Simplified the Helm install command for `cert-manager` by removing an unnecessary feature gate parameter.