### PR TITLE
Revert "Disable buggy strict path validation (#30)"

### DIFF
--- a/init.cfg.tftpl
+++ b/init.cfg.tftpl
@@ -34,8 +34,7 @@ runcmd:
     microk8s helm3 install ingress-nginx ingress-nginx/ingress-nginx --namespace ingress-nginx --create-namespace \
       --set "controller.service.type=NodePort" \
       --set "controller.service.nodePorts.http=${http_port}" \
-      --set "controller.service.nodePorts.https=${https_port}" \
-      --set "controller.config.strict-validate-path-type=false"
+      --set "controller.service.nodePorts.https=${https_port}"
   - |
     if [ "${enable_cert_manager}" = "true" ]; then
       echo "Installing cert-manager ..."


### PR DESCRIPTION
This reverts commit f4dfb81c5d712583eb11182e68f2687032aa5d40.

This pull request makes a minor update to the `init.cfg.tftpl` configuration by removing the `controller.config.strict-validate-path-type=false` option from the Helm install command for `ingress-nginx`. This simplifies the configuration and may restore default path validation behavior.

* Removed the `--set "controller.config.strict-validate-path-type=false"` option from the `microk8s helm3 install ingress-nginx` command in `init.cfg.tftpl`, reverting to the default strict path type validation.