### PR TITLE
Revert "Fix 413 error on image uploads by increasing NGINX body size …

### DIFF
--- a/init.cfg.tftpl
+++ b/init.cfg.tftpl
@@ -37,8 +37,7 @@ runcmd:
       --set "controller.service.httpsPort.nodePort=${https_port}" \
       --set "controller.ingressClass.name=nginx" \
       --set "controller.ingressClass.create=true" \
-      --set "controller.ingressClass.setAsDefaultIngress=false" \
-      --set "controller.config.entries.proxy-body-size=10m"
+      --set "controller.ingressClass.setAsDefaultIngress=false"
   - |
     if [ "${enable_cert_manager}" = "true" ]; then
       echo "Installing cert-manager ..."


### PR DESCRIPTION
This pull request makes a minor update to the `init.cfg.tftpl` configuration file by removing an unnecessary Helm chart setting related to proxy body size for the NGINX ingress controller.

* Removed the `controller.config.entries.proxy-body-size=10m` setting from the Helm install command in `init.cfg.tftpl`, simplifying the NGINX ingress controller configuration.…limit (#44)"

This reverts commit 44f8439b0ced81553880949cd2233a827c0e65b3.