### PR TITLE
Remove deprecated vm_agent_platform_updates_enabled property

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,6 @@ resource "azurerm_linux_virtual_machine" "main" {
   patch_mode                                             = "AutomaticByPlatform"
   patch_assessment_mode                                  = "AutomaticByPlatform"
   bypass_platform_safety_checks_on_user_schedule_enabled = true
-  vm_agent_platform_updates_enabled                      = true
 
   admin_ssh_key {
     username   = local.admin_username


### PR DESCRIPTION
## Remove Deprecated vm_agent_platform_updates_enabled Property

Resolves deprecation warnings from azurerm provider by removing the now read-only property.

## Problem

The azurerm provider has marked `vm_agent_platform_updates_enabled` as deprecated and read-only in the API. When running `terraform plan`, three warnings appear:

```
Warning: Argument is deprecated
with azurerm_linux_virtual_machine.main
on main.tf line 96, in resource "azurerm_linux_virtual_machine" "main":
  vm_agent_platform_updates_enabled = true
this property has been deprecated due to a breaking change introduced by the 
Service team, which redefined it as a read-only field within the API

Warning: Deprecated value used
on outputs.tf line 47, in output "linux_virtual_machine":
  value = azurerm_linux_virtual_machine.main
Deprecated resource attribute "vm_agent_platform_updates_enabled" used.
```

## Solution

Removed the `vm_agent_platform_updates_enabled = true` line from the `azurerm_linux_virtual_machine` resource. This property cannot be set by Terraform and is now managed solely by the Azure platform as a read-only field.

## Platform Update Configuration

The platform update configuration remains fully in place via:
- `patch_mode = "AutomaticByPlatform"`
- `patch_assessment_mode = "AutomaticByPlatform"`
- `bypass_platform_safety_checks_on_user_schedule_enabled = true`

These settings continue to control the automatic patching behavior.

## Changes

- `main.tf`: Removed deprecated `vm_agent_platform_updates_enabled` property

## Impact

- Eliminates all three deprecation warnings
- No functional change to platform update behavior
- Configuration remains valid and operational
